### PR TITLE
Getting the list of snapshots is not paginated so we don't get them all.

### DIFF
--- a/api/v1/api_v1_snapshots.go
+++ b/api/v1/api_v1_snapshots.go
@@ -12,9 +12,15 @@ import (
 // GetIsiSnapshots queries a list of all snapshots on the cluster
 func GetIsiSnapshots(
 	ctx context.Context,
-	client api.Client) (resp *getIsiSnapshotsResp, err error) {
+	client api.Client, scheduleName string) (resp *getIsiSnapshotsResp, err error) {
 	// PAPI call: GET https://1.2.3.4:8080/platform/1/snapshot/snapshots
-	err = client.Get(ctx, snapshotsPath, "", nil, nil, &resp)
+
+	params := api.NewOrderedValues([][]string{})
+
+	if scheduleName != "" {
+		params.StringAdd("schedule", scheduleName)
+	}
+	err = client.Get(ctx, snapshotsPath, "", params, nil, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/api/v1/api_v1_snapshots.go
+++ b/api/v1/api_v1_snapshots.go
@@ -15,9 +15,10 @@ func GetIsiSnapshots(
 	client api.Client, scheduleName string) (resp *getIsiSnapshotsResp, err error) {
 	// PAPI call: GET https://1.2.3.4:8080/platform/1/snapshot/snapshots
 
-	params := api.NewOrderedValues([][]string{})
+	var params api.OrderedValues
 
 	if scheduleName != "" {
+		params = api.NewOrderedValues([][]string{})
 		params.StringAdd("schedule", scheduleName)
 	}
 	err = client.Get(ctx, snapshotsPath, "", params, nil, &resp)

--- a/api/v1/api_v1_types.go
+++ b/api/v1/api_v1_types.go
@@ -88,7 +88,7 @@ type IsiSnapshot struct {
 	ShadowBytes   int64   `json:"shadow_bytes"`
 	Size          int64   `json:"size"`
 	State         string  `json:"state"`
-	TargetId      int64   `json:"target_it"`
+	TargetId      int64   `json:"target_id"`
 	TargetName    string  `json:"target_name"`
 }
 

--- a/snapshots.go
+++ b/snapshots.go
@@ -12,8 +12,8 @@ import (
 type SnapshotList []*api.IsiSnapshot
 type Snapshot *api.IsiSnapshot
 
-func (c *Client) GetSnapshots(ctx context.Context) (SnapshotList, error) {
-	snapshots, err := api.GetIsiSnapshots(ctx, c.API)
+func (c *Client) GetSnapshots(ctx context.Context, scheduleName string) (SnapshotList, error) {
+	snapshots, err := api.GetIsiSnapshots(ctx, c.API, scheduleName)
 	if err != nil {
 		return nil, err
 	}
@@ -24,7 +24,7 @@ func (c *Client) GetSnapshots(ctx context.Context) (SnapshotList, error) {
 func (c *Client) GetSnapshotsByPath(
 	ctx context.Context, path string) (SnapshotList, error) {
 
-	snapshots, err := api.GetIsiSnapshots(ctx, c.API)
+	snapshots, err := api.GetIsiSnapshots(ctx, c.API, "")
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func (c *Client) GetSnapshot(
 	if name == "" {
 		return nil, err
 	}
-	snapshotList, err := c.GetSnapshots(ctx)
+	snapshotList, err := c.GetSnapshots(ctx, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This doesn't paginate, but it makes it so you can filter by the schedule name when you get the list of snapshots. The default limit is 1000 I think so it is reasonable that we won't need to paginate in that case.

This also fixes the issue where we don't detect alias's correctly to ignore them,