### PR TITLE
The API gives an non-meaningful error when you don't have the right permissions

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -316,6 +316,16 @@ func (c *client) DoWithHeaders(
 		if err = dec.Decode(resp); err != nil && err != io.EOF {
 			return err
 		}
+	case res.StatusCode == 403:
+		return &JSONError{
+			StatusCode: 403,
+			Err: []Error{
+				{
+					Code:    "403 Forbidden",
+					Message: "Permissions missing for access to Isilon API. Please check Isilon.",
+				},
+			},
+		}
 	default:
 		return parseJSONError(res)
 	}


### PR DESCRIPTION
Right now, when a 403 comes back, it doesn't give a meaningful error. Just that `<` is an invalid character. This makes it give us back something we can actually use as a meaningful error message.